### PR TITLE
add wildcard boolean options for tls.ini

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,0 @@
-
-1.0.3 - 2016-10-25
-
-* added tls.ini loading
-

--- a/Changes.md
+++ b/Changes.md
@@ -1,0 +1,9 @@
+
+1.0.4 - 2016-10-25
+
+* initialize TLS opts in (section != main) as booleans
+
+1.0.3 - 2016-10-25
+
+* added tls.ini loading
+

--- a/index.js
+++ b/index.js
@@ -365,10 +365,19 @@ exports.ip_in_list = function (list, ip) {
 exports.load_tls_ini = function (cb) {
   var cfg = exports.config.get('tls.ini', {
     booleans: [
+      '-redis.disable_for_failed_hosts',
+
+      // wildcards match in any section and are not initialized
+      '*.requestCert',
+      '*.rejectUnauthorized',
+      '*.honorCipherOrder',
+      '*.enableOCSPStapling',
+
+      // explicitely declared booleans are initialized
       '+main.requestCert',
       '-main.rejectUnauthorized',
       '-main.honorCipherOrder',
-      '-redis.disable_for_failed_hosts',
+      '-main.enableOCSPStapling',
     ]
   }, cb);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-net-utils",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "haraka network utilities",
   "main": "index.js",
   "scripts": {
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "async": "^2.0.1",
-    "haraka-config": "^1.0.3",
+    "haraka-config": ">=1.0.5",
     "haraka-tld": "*",
     "ipaddr.js": "^1.2.0",
     "sprintf-js": "^1.0.3"

--- a/test/config/tls.ini
+++ b/test/config/tls.ini
@@ -7,6 +7,7 @@ ciphers = ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256
 rejectUnauthorized=true
 requestCert=true
 honorCipherOrder=true
+enableOCSPStapling=true
 
 
 [redis]
@@ -34,3 +35,4 @@ ciphers = ECDHE-RSA-AES256-GCM-SHA384
 rejectUnauthorized=false
 requestCert=false
 honorCipherOrder=false
+enableOCSPStapling=false

--- a/test/net_utils.js
+++ b/test/net_utils.js
@@ -955,42 +955,51 @@ exports.ip_in_list = {
 };
 
 exports.load_tls_ini = {
-  'loads a tls.ini config file (defaults)': function (test) {
+  setUp : function (done) {
+    this.net_utils = require('../index');
+    done();
+  },
+  'loads missing tls.ini default config': function (test) {
     test.expect(1);
+    this.net_utils.config = this.net_utils.config.module_config(path.resolve('non-exist'));
     test.deepEqual(net_utils.load_tls_ini(),
       { main:
        { requestCert: true,
          rejectUnauthorized: false,
-         honorCipherOrder: false
+         honorCipherOrder: false,
+         enableOCSPStapling: false,
        },
       redis: { disable_for_failed_hosts: false },
       no_tls_hosts: {}
     });
     test.done();
   },
-  'loads a tls.ini config file from test dir': function (test) {
+  'loads tls.ini from test dir': function (test) {
     test.expect(1);
-    net_utils.config = net_utils.config.module_config(path.resolve('test'));
+    this.net_utils.config = this.net_utils.config.module_config(path.resolve('test'));
     test.deepEqual(net_utils.load_tls_ini(),
       { main:
        { requestCert: true,
          rejectUnauthorized: true,
          honorCipherOrder: true,
+         enableOCSPStapling: true,
          key: 'tls_key.pem',
          cert: 'tls_cert.pem',
          dhparam: 'dhparams.pem',
          ciphers: 'ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384' },
       redis: { disable_for_failed_hosts: false },
       no_tls_hosts: {},
-      outbound:
-       { key: 'tls_key.pem',
-         cert: 'tls_cert.pem',
-         dhparam: 'dhparams.pem',
-         ciphers: 'ECDHE-RSA-AES256-GCM-SHA384',
-         rejectUnauthorized: 'false',
-         requestCert: 'false',
-         honorCipherOrder: 'false' }
-       }
+      outbound: {
+        key: 'tls_key.pem',
+        cert: 'tls_cert.pem',
+        dhparam: 'dhparams.pem',
+        ciphers: 'ECDHE-RSA-AES256-GCM-SHA384',
+        rejectUnauthorized: false,
+        requestCert: false,
+        honorCipherOrder: false,
+        enableOCSPStapling: false,
+      }
+      }
     );
     test.done();
   },


### PR DESCRIPTION
* so that properties like requestCert get initialized as booleans, even when located in sections != main (like [outbound], [smtp_forward], etc..)