### PR TITLE
skip loading expired x509 (TLS) certs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,11 @@
 
+1.0.8 - 2017-03-08
+
+- skip loading expired x509 (TLS) certs
+- make TLS cert dir configurable
+- rename certs -> cert (be consistent with haraka/plugins/tls)
+- store cert/key as buffers (was strings)
+
 1.0.7 - 2017-03-08
 
 - handle undefined tls.ini section

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-net-utils",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "haraka network utilities",
   "main": "index.js",
   "scripts": {

--- a/test/net_utils.js
+++ b/test/net_utils.js
@@ -1065,7 +1065,13 @@ exports.parse_x509_names = {
     test.deepEqual(r, ['foo.nictool.com', 'nictool.com', 'nictool.org', 'www.nictool.com', 'www.nictool.org']);
 
     test.done();
-  }
+  },
+  'extracts expiration date': function (test) {
+    test.expect(1);
+    var r = this.net_utils.parse_x509_expire('foo', 'Validity\n            Not Before: Mar  4 23:28:49 2017 GMT\n            Not After : Mar  3 23:28:49 2023 GMT\n        Subject');
+    test.deepEqual(r, new Date('2023-03-03T23:28:49.000Z'));
+    test.done();
+  },
 }
 
 exports.load_tls_dir = {
@@ -1077,7 +1083,7 @@ exports.load_tls_dir = {
   },
   'loads tls files from config/tls': function (test) {
     test.expect(5);
-    this.net_utils.load_tls_dir(function (err, res) {
+    this.net_utils.load_tls_dir('tls', function (err, res) {
       test.equal(err, null);
       // console.log(res);
       // console.log(res[0]);
@@ -1086,7 +1092,7 @@ exports.load_tls_dir = {
         test.ok(res[0].key.length);
         test.ok(res[0].names.length);
         // console.log(res[0].key);
-        test.ok(res[0].certs.length);
+        test.ok(res[0].cert.length);
       }
       test.done();
     })


### PR DESCRIPTION
- skip loading expired x509 (TLS) certs
- make TLS cert dir configurable
- rename variable certs -> cert (be consistent with haraka/plugins/tls)
- store cert/key as buffers (was strings)