### PR TITLE
fix: restore checks for address list interator

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,8 @@
 
+### 1.2.3 - 2020-12-19
+
+- fix: restore the tests wrapping the resolveMX iterable
+
 ### 1.2.2 - 2020-12-15
 
 - get_mx: do not include implicit MX

--- a/index.js
+++ b/index.js
@@ -422,8 +422,10 @@ exports.get_mx = function get_mx (raw_domain, cb) {
 
   dns.resolveMx(domain, (err, addresses) => {
 
-    for (const addr of addresses) {
-      mxs.push(wrap_mx(addr));
+    if (addresses && addresses.length) {
+      for (const addr of addresses) {
+        mxs.push(wrap_mx(addr));
+      }
     }
 
     cb(err, mxs);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-net-utils",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "haraka network utilities",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
resolveMx may not return an Iterable, which may result in this.

````
[CRIT] [-] [core]     at QueryReqWrap.callback (/root/Haraka/node_modules/haraka-net-utils/index.js:425:24)
````