### PR TITLE
Support passing an array to ip_in_list

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,10 @@ Checks to see if an IP is bound locally or an IPv4 or IPv6 localhost address.
 
 ### ip_in_list
 
-    // searches for 'ip' as a hash key in the list object
+    // searches for 'ip' as a hash key in the list object or array
     // ip can be a host, an IP, or an IPv4 or IPv6 range
     net_utils.ip_in_list(object, ip);
+    net_utils.ip_in_list(array, ip);
     net_utils.ip_in_list(tls.no_tls_hosts, '127.0.0.5');
 
 ### get_mx

--- a/index.js
+++ b/index.js
@@ -372,8 +372,8 @@ exports.ipv6_bogus = function (ipv6) {
 exports.ip_in_list = function (list, ip) {
   if (list === undefined) return false;
 
-  let isHostname = !net.isIP(ip);
-  let isArray = Array.isArray(list);
+  const isHostname = !net.isIP(ip);
+  const isArray = Array.isArray(list);
 
   // Quick lookup
   if (!isArray) {

--- a/index.js
+++ b/index.js
@@ -372,12 +372,24 @@ exports.ipv6_bogus = function (ipv6) {
 exports.ip_in_list = function (list, ip) {
   if (list === undefined) return false;
 
-  if (!net.isIP(ip)) return (ip in list); // domain
+  let isHostname = !net.isIP(ip);
+  let isArray = Array.isArray(list);
 
-  for (const string in list) {
-    if (string === ip) return true; // exact match
+  // Quick lookup
+  if (!isArray) {
+    if (ip in list) return true;   // domain or literal IP
+    if (isHostname) return false;  // skip CIDR match
+  }
 
-    const cidr = string.split('/');
+  // Iterate: arrays and CIDR matches
+  for (let item in list) {
+    if (isArray) {
+      item = list[item];             // item is index
+      if (item === ip) return true;  // exact match
+    }
+    if (isHostname) continue;  // skip CIDR match
+
+    const cidr = item.split('/');
     const c_net  = cidr[0];
 
     if (!net.isIP(c_net)) continue;  // bad config entry

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-net-utils",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "description": "haraka network utilities",
   "main": "index.js",
   "scripts": {

--- a/test/net_utils.js
+++ b/test/net_utils.js
@@ -985,7 +985,8 @@ describe('get_ips_by_host', function () {
 })
 
 function _check_list (done, list, ip, res) {
-  assert.equal(net_utils.ip_in_list(list, ip), res);
+  assert.equal(net_utils.ip_in_list(list, ip), res);  // keys of object
+  assert.equal(net_utils.ip_in_list(Object.keys(list), ip), res);  // array
   done();
 }
 


### PR DESCRIPTION
- Adds support for passing the list as an array
- Retains support for passing the "list" as an object (list items as keys, values ignored)
- Duplicates the tests to check each test for both styles
- Bonus: Optimizes the use case where the given IP has an exact match in the given object
- Increases version number so haraka/Haraka#2910 can depend on it
