### PR TITLE
is_local_host refactoring to return a promise

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -3,6 +3,9 @@ env:
   es6: true
   mocha: true
 
+parserOptions:
+  ecmaVersion: 8
+
 plugins:
   - haraka
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,9 @@
 
 #### 1.N.N - YYYY-MM-DD
 
+#### 1.3.3 - 2021-12-20
+
+- refactored is_local_host function to return a promise instead of using a callback #65
 
 #### 1.3.2 - 2021-12-20
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ This module provides network utility functions.
     // For IPv4, returns true if is_private_ipv4 or is_local_ipv4 are true
     // For IPv6, returns true if is_local_ipv6 is true
 
+### is_local_host
+
+Checks to see if a host name resolves to a local ip.
+
 ### is_local_ip
 
 Checks to see if an IP is bound locally or an IPv4 or IPv6 localhost address.

--- a/index.js
+++ b/index.js
@@ -140,6 +140,23 @@ exports.on_local_interface = function (ip) {
   return locallyBoundIPs.includes(ip);
 }
 
+exports.is_local_host = function (host, done) {
+  if (net.isIP(host)) {
+    done([], this.is_local_ip(host));
+    return;
+  }
+
+  const self = this;
+  this.get_ips_by_host(host, function (errors, ips) {
+    if (errors.length) {
+      done(errors, undefined);
+    }
+    else {
+      done([], ips.length ? self.is_local_ip(ips[0]) : false);
+    }
+  });
+}
+
 exports.is_local_ip = function (ip) {
 
   if (this.on_local_interface(ip)) return true;

--- a/index.js
+++ b/index.js
@@ -164,7 +164,7 @@ exports.is_local_ip = function (ip) {
   if (net.isIPv4(ip)) return this.is_local_ipv4(ip);
   if (net.isIPv6(ip)) return this.is_local_ipv6(ip);
 
-  console.error(`invalid IP address: ${ip}`);
+  // console.error(`invalid IP address: ${ip}`);
   return false;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-net-utils",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "haraka network utilities",
   "main": "index.js",
   "scripts": {

--- a/test/net_utils.js
+++ b/test/net_utils.js
@@ -82,11 +82,10 @@ describe('is_ipv4_literal', function () {
   })
 })
 
-function _is_local_host (done, host, expected) {
-  net_utils.is_local_host(host, function (errors, is_local_host) {
-    assert.strictEqual(expected, is_local_host);
-    done();
-  });
+async function _is_local_host (done, host, expected) {
+  const is_local_host = await net_utils.is_local_host(host);
+  assert.strictEqual(expected, is_local_host);
+  done();
 }
 
 function _is_private_ip (done, ip, expected) {
@@ -120,8 +119,13 @@ describe('is_local_host', function () {
     _is_local_host(done, '8.8.8.8', false);
   })
 
-  it('invalid host string', function (done) {
-    _is_local_host(done, 'invalid host string', undefined);
+  // test that a hostname resolving to IPs of a single version (IPv4 in this case) doesn't fail
+  it('outlook-com.olc.protection.outlook.com', function (done) {
+    _is_local_host(done, 'outlook-com.olc.protection.outlook.com', false);
+  })
+
+  it('invalid host string', async function () {
+    await assert.rejects(net_utils.is_local_host('invalid host string'));
   })
 })
 

--- a/test/net_utils.js
+++ b/test/net_utils.js
@@ -82,6 +82,13 @@ describe('is_ipv4_literal', function () {
   })
 })
 
+function _is_local_host (done, host, expected) {
+  net_utils.is_local_host(host, function (errors, is_local_host) {
+    assert.strictEqual(expected, is_local_host);
+    done();
+  });
+}
+
 function _is_private_ip (done, ip, expected) {
   assert.equal(expected, net_utils.is_private_ip(ip));
   done();
@@ -91,6 +98,32 @@ function _is_local_ip (done, ip, expected) {
   assert.equal(expected, net_utils.is_local_ip(ip));
   done();
 }
+
+describe('is_local_host', function () {
+  it('127.0.0.1', function (done) {
+    _is_local_host(done, '127.0.0.1', true);
+  })
+
+  it('0.0.0.0', function (done) {
+    _is_local_host(done, '0.0.0.0', true);
+  })
+
+  it('::1', function (done) {
+    _is_local_host(done, '::1', true);
+  })
+
+  it('google.com', function (done) {
+    _is_local_host(done, 'google.com', false);
+  })
+
+  it('8.8.8.8', function (done) {
+    _is_local_host(done, '8.8.8.8', false);
+  })
+
+  it('invalid host string', function (done) {
+    _is_local_host(done, 'invalid host string', undefined);
+  })
+})
 
 describe('is_local_ip', function () {
   it('127.0.0.1', function (done) {

--- a/test/net_utils.js
+++ b/test/net_utils.js
@@ -119,11 +119,6 @@ describe('is_local_host', function () {
     _is_local_host(done, '8.8.8.8', false);
   })
 
-  // test that a hostname resolving to IPs of a single version (IPv4 in this case) doesn't fail
-  it('outlook-com.olc.protection.outlook.com', function (done) {
-    _is_local_host(done, 'outlook-com.olc.protection.outlook.com', false);
-  })
-
   it('invalid host string', async function () {
     await assert.rejects(net_utils.is_local_host('invalid host string'));
   })


### PR DESCRIPTION
Refactors `is_local_host` to use promises.

This makes its use easier in `Haraka/outbound/mx_lookup.js`, though I'm not sure this complies with the project code guidelines as I haven't seen use of promises elsewhere in it so far.