### PR TITLE
ci: enable CI tests on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 
-on:
-  push:
+on: [ pull_request, push ]
 
 env:
   CI: true

--- a/test/net_utils.js
+++ b/test/net_utils.js
@@ -1202,7 +1202,7 @@ describe('get_mx', function () {
 
   for (const c in validCases) {
     it(`gets MX records for ${c}`, function (done) {
-      this.timeout(3000)
+      this.timeout(5000)
       this.net_utils.get_mx(c, (err, mxlist) => {
         if (err) console.error(err)
         assert.ifError(err);
@@ -1213,7 +1213,7 @@ describe('get_mx', function () {
     })
 
     it(`awaits MX records for ${c}`, async function () {
-      this.timeout(4000)
+      this.timeout(5000)
       const mxlist = await this.net_utils.get_mx(c)
       // assert.ok(mxlist.length);
       checkValid(validCases[c], mxlist)

--- a/test/net_utils.js
+++ b/test/net_utils.js
@@ -1054,7 +1054,7 @@ describe('get_ips_by_host', function () {
   for (const t in tests) {
 
     it(`get_ips_by_host, ${t}`, function (done) {
-      this.timeout(4000)
+      this.timeout(5000)
       net_utils.get_ips_by_host(t, function (err, res) {
         if (err && err.length) {
           console.error(err);

--- a/test/net_utils.js
+++ b/test/net_utils.js
@@ -1213,7 +1213,7 @@ describe('get_mx', function () {
     })
 
     it(`awaits MX records for ${c}`, async function () {
-      this.timeout(3000)
+      this.timeout(4000)
       const mxlist = await this.net_utils.get_mx(c)
       // assert.ok(mxlist.length);
       checkValid(validCases[c], mxlist)


### PR DESCRIPTION
and increase DNS timeouts from 3s to 5s, to reduce intermittent test failures.