### PR TITLE
CVE-2024-29415: ip SSRF improper categorization in isPublic

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,5 @@
     "punycode.js": "^2.3.1",
     "openssl-wrapper": "^0.3.4",
     "sprintf-js": "^1.1.3"
-  },
-  "optionalDependencies": {
-    "@msimerson/stun": "^3.0.1"
   }
 }

--- a/test/get_mx.js
+++ b/test/get_mx.js
@@ -92,7 +92,7 @@ describe('get_mx', function () {
 
     const expectedResolvedMx = [
       {
-        exchange: '2605:ae00:329::14',
+        exchange: '2605:ae00:329::6',
         priority: 10,
         from_dns: 'mail.theartfarm.com',
       },


### PR DESCRIPTION
Hello - could we remove `@msimerson/stun` package as an optional dependency for this package?

It includes `ip` package that has an open CVE and does not seem to be maintained anymore: https://github.com/advisories/GHSA-78xj-cgh5-2h22?

```
$ npm audit
# npm audit report

ip  *
Severity: high
ip SSRF improper categorization in isPublic - https://github.com/advisories/GHSA-2p57-rm9w-gvfp
No fix available
node_modules/ip
  @msimerson/stun  *
  Depends on vulnerable versions of ip
  node_modules/@msimerson/stun

2 high severity vulnerabilities
```