### PR TITLE
Proxy Helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ const hex = net_utils.dec_to_hex(20111104) // 132df00
 const dec = net_utils.hex_to_dec('132df00') // 20111104
 ```
 
+### normalize_ip
+
+Normalizes an IPv4 or IPv6 address to canonical form. Returns `null` for invalid input. IPv4-mapped IPv6 addresses are converted to IPv4.
+
+```js
+net_utils.normalize_ip('1.2.3.4') // '1.2.3.4'
+net_utils.normalize_ip('0000:0000:0000:0000:0000:0000:0000:0001') // '::1'
+net_utils.normalize_ip('::ffff:127.0.0.1') // '127.0.0.1'
+net_utils.normalize_ip('not-an-ip') // null
+```
+
 ### is_local_ipv4
 
 ```js
@@ -105,6 +116,45 @@ try {
 } catch (err) {
   // handle any errors
 }
+```
+
+### parse_proxy_line
+
+Parses an HAProxy PROXY protocol v1 line. Accepts the full line (`PROXY TCP4 …`) or the payload after the command word (`TCP4 …`, as Haraka passes to `cmd_proxy`). Strips a trailing newline if present. Returns `null` for invalid or unsupported lines (including `UNKNOWN`).
+
+```js
+net_utils.parse_proxy_line('PROXY TCP4 127.0.0.1 127.0.0.2 42310 465')
+// {
+//   type: 'haproxy',
+//   proto: 'TCP4',
+//   src_ip: '127.0.0.1',
+//   src_port: '42310',
+//   dst_ip: '127.0.0.2',
+//   dst_port: '465',
+// }
+
+net_utils.parse_proxy_line('TCP6 ::1 ::1 2525 25') // same shape, proto: 'TCP6'
+net_utils.parse_proxy_line('UNKNOWN 1.2.3.4 1.2.3.4 2525 25') // null
+```
+
+### is_haproxy_allowed
+
+Returns whether a connecting IP is allowed to send the HAProxy PROXY command, based on `connection.ini` `[haproxy]` settings. The IP is normalized before matching. Hosts may be listed as exact addresses or CIDR ranges. Returns `false` when HAProxy is disabled, the IP is invalid, or no host entry matches (including an empty `hosts[]` list).
+
+Configure in `config/connection.ini`:
+
+```ini
+[haproxy]
+enabled = true
+hosts[] = 10.0.0.1
+hosts[] = 10.0.0.0/24
+hosts[] = 2001:db8::1
+```
+
+```js
+net_utils.is_haproxy_allowed('10.0.0.1') // true if listed or in a matching CIDR
+net_utils.is_haproxy_allowed('8.8.8.8') // false
+net_utils.is_haproxy_allowed('::ffff:10.0.0.1') // true when 10.0.0.1 is listed
 ```
 
 ### get_mx

--- a/index.js
+++ b/index.js
@@ -281,6 +281,11 @@ exports.ip_in_list = function (list, ip) {
   return false
 }
 
+exports.normalize_ip = function (ip) {
+  if (!net.isIP(ip)) return null
+  return ipaddr.process(ip).toString()
+}
+
 exports.get_primary_host_name = function () {
   return exports.config.get('me') || os.hostname()
 }
@@ -325,4 +330,52 @@ exports.add_line_processor = (socket) => {
     }
     current_data = ''
   })
+}
+
+exports.parse_proxy_line = function (line) {
+  const proxyLine = line?.toString().replace(/\r?\n$/, '')
+  const match = /^(?:PROXY )?(TCP4|TCP6|UNKNOWN) (\S+) (\S+) (\d+) (\d+)$/.exec(proxyLine)
+  if (!match) return null
+
+  const proto = match[1]
+  const src_ip = match[2]
+  const dst_ip = match[3]
+  const src_port = match[4]
+  const dst_port = match[5]
+
+  if (proto === 'TCP4' && ipaddr.IPv4.isValid(src_ip) && ipaddr.IPv4.isValid(dst_ip)) {
+    return { type: 'haproxy', proto, src_ip, src_port, dst_ip, dst_port }
+  }
+
+  if (proto === 'TCP6' && ipaddr.IPv6.isValid(src_ip) && ipaddr.IPv6.isValid(dst_ip)) {
+    return { type: 'haproxy', proto, src_ip, src_port, dst_ip, dst_port }
+  }
+
+  return null
+}
+
+exports.is_haproxy_allowed = function (ip) {
+  const haproxyConfig = exports.config.get('connection.ini', {
+    booleans: ['+haproxy.enabled'],
+  })?.haproxy ?? {}
+  const haproxyEnabled = haproxyConfig.enabled !== false
+  const haproxy_hosts_ipv4 = []
+  const haproxy_hosts_ipv6 = []
+
+  if (!haproxyEnabled) return false
+
+  const normalized_ip = exports.normalize_ip(ip)
+  if (!normalized_ip) return false
+
+  for (const host of haproxyConfig.hosts ?? []) {
+    if (!host) continue
+    if (net.isIPv6(host.split('/')[0])) {
+      haproxy_hosts_ipv6.push([ipaddr.IPv6.parse(host.split('/')[0]), parseInt(host.split('/')[1] || 64)])
+    } else {
+      haproxy_hosts_ipv4.push([ipaddr.IPv4.parse(host.split('/')[0]), parseInt(host.split('/')[1] || 32)])
+    }
+  }
+
+  const ha_list = net.isIPv6(normalized_ip) ? haproxy_hosts_ipv6 : haproxy_hosts_ipv4
+  return ha_list.some((element) => ipaddr.parse(normalized_ip).match(element[0], element[1]))
 }

--- a/test/config/connection.ini
+++ b/test/config/connection.ini
@@ -1,0 +1,4 @@
+[haproxy]
+enabled = true
+hosts[] = 1.2.3.4
+hosts[] = 2001:0:1234::c1c0:abcd:876

--- a/test/haproxy-cidr/config/connection.ini
+++ b/test/haproxy-cidr/config/connection.ini
@@ -1,0 +1,3 @@
+[haproxy]
+enabled = true
+hosts[] = 1.2.3.0/24

--- a/test/haproxy-disabled/config/connection.ini
+++ b/test/haproxy-disabled/config/connection.ini
@@ -1,0 +1,3 @@
+[haproxy]
+enabled = false
+hosts[] = 1.2.3.4

--- a/test/haproxy-empty-hosts/config/connection.ini
+++ b/test/haproxy-empty-hosts/config/connection.ini
@@ -1,0 +1,2 @@
+[haproxy]
+enabled = true

--- a/test/net_utils.js
+++ b/test/net_utils.js
@@ -524,6 +524,33 @@ describe('ip_in_list', function () {
   })
 })
 
+describe('normalize_ip', function () {
+  it('1.2', function () {
+    assert.equal(net_utils.normalize_ip('1.2'), null)
+  })
+  it('empty string', function () {
+    assert.equal(net_utils.normalize_ip(''), null)
+  })
+  it('null', function () {
+    assert.equal(net_utils.normalize_ip(null), null)
+  })
+  it('1.2.3.4', function () {
+    assert.equal(net_utils.normalize_ip('1.2.3.4'), '1.2.3.4')
+  })
+  it('2001:0:1234::c1c0:abcd:876', function () {
+    assert.equal(net_utils.normalize_ip('2001:0:1234::c1c0:abcd:876'), '2001:0:1234::c1c0:abcd:876')
+  })
+  it('2001:0:1234::C1C0:ABCD:876', function () {
+    assert.equal(net_utils.normalize_ip('2001:0:1234::C1C0:ABCD:876'), '2001:0:1234::c1c0:abcd:876')
+  })
+  it('0000:0000:0000:0000:0000:0000:0000:0001', function () {
+    assert.equal(net_utils.normalize_ip('0000:0000:0000:0000:0000:0000:0000:0001'), '::1')
+  })
+  it('::ffff:127.0.0.1', function () {
+    assert.equal(net_utils.normalize_ip('::ffff:127.0.0.1'), '127.0.0.1')
+  })
+})
+
 describe('get_primary_host_name', () => {
   let net_utils_mod
   beforeEach(() => {
@@ -627,5 +654,107 @@ describe('add_line_processor', () => {
       net_utils_mod.add_line_processor(socket)
       socket.emit('data', 'A'.repeat(5 * 1024 * 1024)) // 5 MB, no newline
     })
+  })
+})
+
+describe('parse_proxy_line', function () {
+  it('PROXY TCP4 127.0.0.1 127.0.0.2 42310 465', function () {
+    assert.deepEqual(net_utils.parse_proxy_line('PROXY TCP4 127.0.0.1 127.0.0.2 42310 465'), { type: 'haproxy', proto: 'TCP4', src_ip: '127.0.0.1', src_port: '42310', dst_ip: '127.0.0.2', dst_port: '465' })
+  })
+  it('TCP4 127.0.0.1 127.0.0.2 42310 465', function () {
+    assert.deepEqual(net_utils.parse_proxy_line('TCP4 127.0.0.1 127.0.0.2 42310 465'), { type: 'haproxy', proto: 'TCP4', src_ip: '127.0.0.1', src_port: '42310', dst_ip: '127.0.0.2', dst_port: '465' })
+  })
+  it('TCP4 127.0.0.1 127.0.0.2 42310 465\\r\\n', function () {
+    assert.deepEqual(net_utils.parse_proxy_line('TCP4 127.0.0.1 127.0.0.2 42310 465\r\n'), { type: 'haproxy', proto: 'TCP4', src_ip: '127.0.0.1', src_port: '42310', dst_ip: '127.0.0.2', dst_port: '465' })
+  })
+  it('PROXY TCP4 nope 127.0.0.1 42310 465', function () {
+    assert.deepEqual(net_utils.parse_proxy_line('PROXY TCP4 nope 127.0.0.1 42310 465'), null)
+  })
+  it('PROXY TCP6 2001:0:1234::c1c0:abcd:876 2001:0:1234::c1c0:abcd:876 2525 25', function () {
+    assert.deepEqual(net_utils.parse_proxy_line('PROXY TCP6 2001:0:1234::c1c0:abcd:876 2001:0:1234::c1c0:abcd:876 2525 25'), { type: 'haproxy', proto: 'TCP6', src_ip: '2001:0:1234::c1c0:abcd:876', src_port: '2525', dst_ip: '2001:0:1234::c1c0:abcd:876', dst_port: '25' })
+  })
+  it('TCP6 ::1 ::1 2525 25', function () {
+    assert.deepEqual(net_utils.parse_proxy_line('TCP6 ::1 ::1 2525 25'), { type: 'haproxy', proto: 'TCP6', src_ip: '::1', src_port: '2525', dst_ip: '::1', dst_port: '25' })
+  })
+  it('UNKNOWN 1.2.3.4 1.2.3.4 2525 25', function () {
+    assert.deepEqual(net_utils.parse_proxy_line('UNKNOWN 1.2.3.4 1.2.3.4 2525 25'), null)
+  })
+  it('PROXY TCP4 1.2.3.4 999.999.999.999 2525 25', function () {
+    assert.deepEqual(net_utils.parse_proxy_line('PROXY TCP4 1.2.3.4 999.999.999.999 2525 25'), null)
+  })
+  it('empty string', function () {
+    assert.deepEqual(net_utils.parse_proxy_line(''), null)
+  })
+  it('null', function () {
+    assert.deepEqual(net_utils.parse_proxy_line(null), null)
+  })
+  it('PROXY TCP4 nope 1.2.3.4 2525 25', function () {
+    assert.deepEqual(net_utils.parse_proxy_line('PROXY TCP4 nope 1.2.3.4 2525 25'), null)
+  })
+})
+
+describe('is_haproxy_allowed', function () {
+  let net_utils_mod
+  beforeEach(() => {
+    net_utils_mod = require('../index')
+    net_utils_mod.config = net_utils_mod.config.module_config(
+      path.resolve('test'),
+    )
+  })
+
+  it('with connection.ini config and IPv4', () => {
+    assert.equal(net_utils_mod.is_haproxy_allowed('1.2.3.4'), true)
+  })
+
+  it('with connection.ini config and IPv6', () => {
+    assert.equal(net_utils_mod.is_haproxy_allowed('2001:0:1234::c1c0:abcd:876'), true)
+  })
+
+  it('without connection.ini config and IPv4', () => {
+    net_utils_mod.config = net_utils_mod.config.module_config(
+      path.resolve('doesnt-exist'),
+    )
+    assert.equal(net_utils_mod.is_haproxy_allowed('1.2.3.4'), false)
+  })
+
+  it('without connection.ini config and IPv6', () => {
+    net_utils_mod.config = net_utils_mod.config.module_config(
+      path.resolve('doesnt-exist'),
+    )
+    assert.equal(net_utils_mod.is_haproxy_allowed('2001:0:1234::c1c0:abcd:876'), false)
+  })
+
+  it('denies IP not in allow list', () => {
+    assert.equal(net_utils_mod.is_haproxy_allowed('8.8.8.8'), false)
+  })
+
+  it('denies invalid IP', () => {
+    assert.equal(net_utils_mod.is_haproxy_allowed('not-an-ip'), false)
+  })
+
+  it('allows IPv4-mapped IPv6 for listed IPv4', () => {
+    assert.equal(net_utils_mod.is_haproxy_allowed('::ffff:1.2.3.4'), true)
+  })
+
+  it('when disabled in config', () => {
+    net_utils_mod.config = net_utils_mod.config.module_config(
+      path.resolve('test/haproxy-disabled'),
+    )
+    assert.equal(net_utils_mod.is_haproxy_allowed('1.2.3.4'), false)
+  })
+
+  it('matches CIDR in hosts', () => {
+    net_utils_mod.config = net_utils_mod.config.module_config(
+      path.resolve('test/haproxy-cidr'),
+    )
+    assert.equal(net_utils_mod.is_haproxy_allowed('1.2.3.99'), true)
+    assert.equal(net_utils_mod.is_haproxy_allowed('1.2.4.1'), false)
+  })
+
+  it('denies all when enabled but hosts empty', () => {
+    net_utils_mod.config = net_utils_mod.config.module_config(
+      path.resolve('test/haproxy-empty-hosts'),
+    )
+    assert.equal(net_utils_mod.is_haproxy_allowed('1.2.3.4'), false)
   })
 })


### PR DESCRIPTION
Extracts proxy related helpers from [`connection.js`](https://github.com/haraka/Haraka/blob/master/connection.js), for use with https://github.com/haraka/Haraka/pull/3577

Adds three new functions:
- `normalize_ip`
  - Normalizes an IPv4 or IPv6 address to canonical form. Returns null if invalid.
- `parse_proxy_line`
  - Parses an HAProxy PROXY protocol v1 line. Returns null if invalid.
- `is_haproxy_allowed`
  -  Checks if proxy is enabled, IP is valid, and IP is in allowlist. Boolean result.